### PR TITLE
patch to fix potential data loss during new project activity

### DIFF
--- a/beecount/src/main/java/com/knirirr/beecount/NewProjectActivity.java
+++ b/beecount/src/main/java/com/knirirr/beecount/NewProjectActivity.java
@@ -95,6 +95,10 @@ public class NewProjectActivity extends AppCompatActivity implements SharedPrefe
 
   }
 
+  private SharedPreferences spGen;
+
+  private boolean isSubmit;
+
   // the required pause and resume stuff
   @Override
   protected void onResume()
@@ -102,6 +106,9 @@ public class NewProjectActivity extends AppCompatActivity implements SharedPrefe
     projectDataSource.open();
     countDataSource.open();
     super.onResume();
+    isSubmit = false;
+    spGen = getSharedPreferences("NewProjectActivity", MODE_PRIVATE);
+    newprojName.setText(spGen.getString("editName", ""));
   }
 
   @Override
@@ -128,6 +135,13 @@ public class NewProjectActivity extends AppCompatActivity implements SharedPrefe
 
   @Override
   protected void onPause() {
+    SharedPreferences.Editor  spEditor = spGen.edit();
+    if(isSubmit){
+      spEditor.putString("editName", "");
+    }else{
+      spEditor.putString("editName", newprojName.getText().toString());
+    }
+    spEditor.commit();
     projectDataSource.close();
     countDataSource.close();
     super.onPause();
@@ -255,7 +269,7 @@ public class NewProjectActivity extends AppCompatActivity implements SharedPrefe
 
     // Huzzah!
     Toast.makeText(this,getString(R.string.projectSaved),Toast.LENGTH_SHORT).show();
-
+    isSubmit = true;
     // Instead of returning to the welcome screen, show the new project.
     //super.finish();
     Intent intent = new Intent(NewProjectActivity.this, ListProjectActivity.class);

--- a/beecount/src/main/java/com/knirirr/beecount/NewProjectActivity.java
+++ b/beecount/src/main/java/com/knirirr/beecount/NewProjectActivity.java
@@ -138,7 +138,8 @@ public class NewProjectActivity extends AppCompatActivity implements SharedPrefe
     SharedPreferences.Editor  spEditor = spGen.edit();
     if(isSubmit){
       spEditor.putString("editName", "");
-    }else{
+    }
+    else {
       spEditor.putString("editName", newprojName.getText().toString());
     }
     spEditor.commit();


### PR DESCRIPTION
Hello developers of BeeCount

I am using your app BeeCount. I think the app is great but I have one minor patch that could improve the user experience.

Here is a picture to help illustrate my patch: https://ibb.co/QMcSvTt

When the user tries to create a new project as can be seen in picture 1.  if the screen focus goes to another app or activity(for example if an incoming call forces the user to go into the phone app), or if the user accidentally closes the app or presses back, the user will lose any data they had put into this page.

This feature will automatically store and restore said data when the user restarts the activity as can be seen in this picture: https://ibb.co/8rf0YPG .Therefore, the user does not have to fill in the data again thus improving the user experience.

I have tested out the feature to ensure it works.

If you have any questions or if you would like me to change anything, please do not hesitate to let me know!

Thank you for your time,
Tim