### PR TITLE
fix for losing data during rotation of device

### DIFF
--- a/beecount/src/main/java/com/knirirr/beecount/CountOptionsActivity.java
+++ b/beecount/src/main/java/com/knirirr/beecount/CountOptionsActivity.java
@@ -48,6 +48,15 @@ public class CountOptionsActivity extends AppCompatActivity implements SharedPre
   private long project_id;
   private boolean pref_multiplier;
 
+  private boolean setting1Check;
+  private boolean setting2Check;
+  private boolean setting3Check;
+  private boolean settingNotesCheck;
+  private int setting1;
+  private int setting2;
+  private int setting3;
+  private String settingNotes;
+
   LinearLayout static_widget_area;
   LinearLayout dynamic_widget_area;
   OptionsWidget ar_value_widget;
@@ -90,8 +99,23 @@ public class CountOptionsActivity extends AppCompatActivity implements SharedPre
       {
         savedAlerts = (ArrayList<AlertCreateWidget>) savedInstanceState.getSerializable("savedAlerts");
       }
+      setting1 = savedInstanceState.getInt("setting1");
+      setting2 = savedInstanceState.getInt("setting2");
+      setting3 = savedInstanceState.getInt("setting3");
+      settingNotes = savedInstanceState.getString("settingNotes");
+      if(setting1 != 0){
+        setting1Check = true;
+      }
+      if(setting2 != 0){
+        setting2Check = true;
+      }
+      if(setting3 != 0){
+        setting3Check = true;
+      }
+      if(settingNotes != null){
+        settingNotesCheck = true;
+      }
     }
-
 
   }
 
@@ -171,6 +195,19 @@ public class CountOptionsActivity extends AppCompatActivity implements SharedPre
     {
       dynamic_widget_area.addView(acw);
     }
+
+    if(setting1Check){
+      ar_value_widget.setParameterValue(setting1);
+    }
+    if(setting2Check){
+      ar_level_widget.setParameterValue(setting2);
+    }
+    if(setting3Check){
+      curr_val_widget.setParameterValue(setting3);
+    }
+    if(settingNotesCheck){
+      enw.setProjectName(settingNotes);
+    }
   }
 
   @Override
@@ -186,6 +223,10 @@ public class CountOptionsActivity extends AppCompatActivity implements SharedPre
       ((ViewGroup) acw.getParent()).removeView(acw);
     }
     outState.putSerializable("savedAlerts", savedAlerts);
+    outState.putInt("setting1", ar_value_widget.getParameterValue());
+    outState.putInt("setting2", ar_level_widget.getParameterValue());
+    outState.putInt("setting3", curr_val_widget.getParameterValue());
+    outState.putString("settingNotes", enw.getProjectName());
   }
 
   @Override


### PR DESCRIPTION
Hello again Knirirr

I was using the BeeCount app and I noticed another activity that can lead to data loss. When the user goes to edit the count settings for an item as can be seen here: https://ibb.co/N2LHbNJ

If the screen focus goes to another app or activity(for example if an incoming call forces the user to go into the phone app), or if the user rotates the phone and changes the app to landscape mode, the user will lose any data they had put into this page as can be seen here: https://ibb.co/C09QQCf

I have used savedInstanceState to automatically save the data in such cases and restore the data when the user returns to the BeeCount app(and hence the activity) or after the phone is rotated. Therefore, the user does not have to fill in the data again thus improving the user experience.

I have tested out the feature to ensure it works.

If you have any questions or if you would like me to change anything, please do not hesitate to let me know!

Thank you for your time,
Tim