### PR TITLE
fix: fix app crash when receiving illegal input

### DIFF
--- a/beecount/src/main/java/com/knirirr/beecount/widgets/OptionsWidget.java
+++ b/beecount/src/main/java/com/knirirr/beecount/widgets/OptionsWidget.java
@@ -49,13 +49,10 @@ public class OptionsWidget extends LinearLayout
   public int getParameterValue()
   {
     String text = number.getText().toString();
-    if (StringUtils.isEmpty(text))
-    {
-      return Integer.valueOf(0);
-    }
-    else
-    {
+    try {
       return Integer.parseInt(text);
+    } catch (Exception ignore) {
+      return 0;
     }
   }
 


### PR DESCRIPTION
Hello, I found the app crash when receiving illegal Integer inputs.
Here is the stacktrace.
```Java
E FATAL EXCEPTION: main
  Process: com.knirirr.beecount, PID: 5684
  java.lang.IllegalStateException: Could not execute method for android:onClick
  	at androidx.appcompat.app.AppCompatViewInflater$DeclaredOnClickListener.onClick(AppCompatViewInflater.java:402)
  	at android.view.View.performClick(View.java:6597)
  	at android.view.View.performClickInternal(View.java:6574) at android.view.View.access$3100(View.java:778) at android.view.View$PerformClick.run(View.java:25885)
  	at android.os.Handler.handleCallback(Handler.java:873)
  	at android.os.Handler.dispatchMessage(Handler.java:99)
  	at android.os.Looper.loop(Looper.java:193)
  	at android.app.ActivityThread.main(ActivityThread.java:6669)
  	at java.lang.reflect.Method.invoke(Native Method)
  	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
  	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
  Caused by: java.lang.reflect.InvocationTargetException
  	at java.lang.reflect.Method.invoke(Native Method)
  	at androidx.appcompat.app.AppCompatViewInflater$DeclaredOnClickListener.onClick(AppCompatViewInflater.java:397)
  	at android.view.View.performClick(View.java:6597) 
  	at android.view.View.performClickInternal(View.java:6574) 
  	at android.view.View.access$3100(View.java:778) 
  	at android.view.View$PerformClick.run(View.java:25885) 
  	at android.os.Handler.handleCallback(Handler.java:873) 
  	at android.os.Handler.dispatchMessage(Handler.java:99) 
  	at android.os.Looper.loop(Looper.java:193) 
  	at android.app.ActivityThread.main(ActivityThread.java:6669) 
  	at java.lang.reflect.Method.invoke(Native Method) 
  	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493) 
  	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858) 
  Caused by: java.lang.NumberFormatException: For input string: "0*N"
  	at java.lang.Integer.parseInt(Integer.java:615)
  	at java.lang.Integer.parseInt(Integer.java:650)
  	at com.knirirr.beecount.widgets.OptionsWidget.getParameterValue(OptionsWidget.java:58)
  	at com.knirirr.beecount.CountOptionsActivity.saveData(CountOptionsActivity.java:215)
  	at com.knirirr.beecount.CountOptionsActivity.saveAndExit(CountOptionsActivity.java:204)
  	at java.lang.reflect.Method.invoke(Native Method) 
  	at androidx.appcompat.app.AppCompatViewInflater$DeclaredOnClickListener.onClick(AppCompatViewInflater.java:397) 
  	at android.view.View.performClick(View.java:6597) 
  	at android.view.View.performClickInternal(View.java:6574) 
  	at android.view.View.access$3100(View.java:778) 
  	at android.view.View$PerformClick.run(View.java:25885) 
  	at android.os.Handler.handleCallback(Handler.java:873) 
  	at android.os.Handler.dispatchMessage(Handler.java:99) 
  	at android.os.Looper.loop(Looper.java:193) 
  	at android.app.ActivityThread.main(ActivityThread.java:6669) 
  	at java.lang.reflect.Method.invoke(Native Method) 
  	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493) 
  	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
```

Here is a video shows how to trigger this crash.

https://user-images.githubusercontent.com/32957242/234162862-5cf5b377-329f-45ac-bd1b-dc439495d076.mp4

I have fixed this by adding a try-catch when parsing values.