### PR TITLE
Fix import in newer android versions.

### DIFF
--- a/beecount/src/main/java/com/knirirr/beecount/WelcomeActivity.java
+++ b/beecount/src/main/java/com/knirirr/beecount/WelcomeActivity.java
@@ -147,7 +147,7 @@ public class WelcomeActivity extends AppCompatActivity implements SharedPreferen
   }
 
   /*
-   * The three activities below are for exporting and importing the database. They've been put here because
+   * The two activities below are for exporting and importing the database. They've been put here because
    * no database should be open at this point.
    */
   private final ActivityResultLauncher<Intent> exportFileLauncher = registerForActivityResult(

--- a/beecount/src/main/java/com/knirirr/beecount/WelcomeActivity.java
+++ b/beecount/src/main/java/com/knirirr/beecount/WelcomeActivity.java
@@ -1,20 +1,11 @@
 package com.knirirr.beecount;
 
-import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.AlertDialog;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.content.pm.PackageManager;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
-import android.os.Environment;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.app.AppCompatDelegate;
-
-import android.preference.PreferenceManager;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -28,7 +19,12 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatDelegate;
 import sheetrock.panda.changelog.ChangeLog;
 
 
@@ -39,14 +35,6 @@ public class WelcomeActivity extends AppCompatActivity implements SharedPreferen
   BeeCountApplication beeCount;
   SharedPreferences prefs;
   ChangeLog cl;
-  final private int REQUEST_CODE_ASK_PERMISSIONS = 123;
-
-  // import/export stuff
-  File infile;
-  File outfile;
-  boolean mExternalStorageAvailable = false;
-  boolean mExternalStorageWriteable = false;
-  String state = Environment.getExternalStorageState();
   AlertDialog alert;
 
   @Override
@@ -162,184 +150,84 @@ public class WelcomeActivity extends AppCompatActivity implements SharedPreferen
    * The three activities below are for exporting and importing the database. They've been put here because
    * no database should be open at this point.
    */
+  private final ActivityResultLauncher<Intent> exportFileLauncher = registerForActivityResult(
+    new ActivityResultContracts.StartActivityForResult(),
+    result -> {
+      if (result.getResultCode() == RESULT_OK && result.getData() != null && result.getData().getData() != null) {
+        Uri uri = result.getData().getData();
+        File infile = getApplicationContext().getDatabasePath("beecount.db");
 
+        try (FileOutputStream out = (FileOutputStream) getContentResolver().openOutputStream(uri);
+             FileInputStream in = new FileInputStream(infile)) {
+          if (out == null) {
+            throw new IOException("OutputStream is null");
+          }
 
-  private static final int CREATE_FILE = 1;
+          byte[] buf = new byte[1024];
+          int len;
+          while ((len = in.read(buf)) > 0) {
+              out.write(buf, 0, len);
+          }
+          Toast.makeText(getApplicationContext(), getString(R.string.saveWin), Toast.LENGTH_LONG).show();
+        } catch (IOException e) {
+          Log.e(TAG, "Failed to export database: " + e);
+          Toast.makeText(getApplicationContext(), getString(R.string.saveFail), Toast.LENGTH_SHORT).show();
+        }
+      }
+    }
+  );
 
   @SuppressLint("SdCardPath")
   public void exportDb()
   {
-    // if API level > 23
-    // Need to do this to write the database file.
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
-    {
-      int hasWriteStoragePermission = checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE);
-      if (hasWriteStoragePermission != PackageManager.PERMISSION_GRANTED)
-      {
-        requestPermissions(new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, REQUEST_CODE_ASK_PERMISSIONS);
-      }
-    }
-    boolean mExternalStorageAvailable = false;
-    boolean mExternalStorageWriteable = false;
-    String state = Environment.getExternalStorageState();
-    File outfile = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),"beecount.db");
-    File infile = getApplicationContext().getDatabasePath("beecount.db");
-
-    if (Environment.MEDIA_MOUNTED.equals(state))
-    {
-      // We can read and write the media
-      mExternalStorageAvailable = mExternalStorageWriteable = true;
-    }
-    else if (Environment.MEDIA_MOUNTED_READ_ONLY.equals(state))
-    {
-      // We can only read the media
-      mExternalStorageAvailable = true;
-      mExternalStorageWriteable = false;
-    }
-    else
-    {
-      // Something else is wrong. It may be one of many other states, but all we need
-      //  to know is we can neither read nor write
-      mExternalStorageWriteable = false;
-    }
-
-    if ((mExternalStorageAvailable == false) || ( mExternalStorageWriteable == false))
-    {
-      Log.e(TAG,"No sdcard access");
-      Toast.makeText(this, getString(R.string.noCard), Toast.LENGTH_SHORT).show();
-      return;
-    }
-    else
-    {
-      // export the db
-      try
-      {
-        copy(infile, outfile);
-        Toast.makeText(this,getString(R.string.saveWin),Toast.LENGTH_LONG).show();
-        return;
-      }
-      catch (IOException e)
-      {
-        Log.e(TAG,"Failed to copy database: " + e.toString());
-        Toast.makeText(this,getString(R.string.saveFail),Toast.LENGTH_SHORT).show();
-        return;
-      }
-    }
-    /*
     Intent intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
     intent.addCategory(Intent.CATEGORY_OPENABLE);
     intent.setType("application/octet-stream");
     intent.putExtra(Intent.EXTRA_TITLE, "beecount.db");
-
-    // Optionally, specify a URI for the directory that should be opened in
-    // the system file picker when your app creates the document.
-    Uri uri = Uri.parse("file://" + getApplicationContext().getDatabasePath("beecount.db"));
-    Toast.makeText(this, "Trying to export..." + getApplicationContext().getDatabasePath("beecount.db")  ,Toast.LENGTH_LONG).show();
-    intent.putExtra(Environment.DIRECTORY_DOWNLOADS, uri);
-
-    startActivityForResult(intent, CREATE_FILE);
-     */
-
+    exportFileLauncher.launch(intent);
   }
+
+  private final ActivityResultLauncher<Intent> importFileLauncher = registerForActivityResult(
+    new ActivityResultContracts.StartActivityForResult(),
+    result -> {
+      if (result.getResultCode() == RESULT_OK && result.getData() != null && result.getData().getData() != null) {
+        Uri uri = result.getData().getData();
+        File outfile = getApplicationContext().getDatabasePath("beecount.db");
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        builder.setIcon(android.R.drawable.ic_dialog_alert);
+        builder.setMessage(R.string.confirmImport).setCancelable(false)
+                .setPositiveButton(R.string.importButton, (dialog, id) -> {
+                  try (InputStream in = getContentResolver().openInputStream(uri);
+                       FileOutputStream out = new FileOutputStream(outfile)) {
+
+                    if (in == null) {
+                      throw new IOException("InputStream is null");
+                    }
+
+                    byte[] buf = new byte[1024];
+                    int len;
+                    while ((len = in.read(buf)) > 0) {
+                      out.write(buf, 0, len);
+                    }
+                    Toast.makeText(getApplicationContext(), getString(R.string.importWin), Toast.LENGTH_SHORT).show();
+                  } catch (IOException e) {
+                    Log.e(TAG, "Failed to import database: " + e);
+                    Toast.makeText(getApplicationContext(), getString(R.string.importFail), Toast.LENGTH_SHORT).show();
+                  }
+                })
+                .setNegativeButton(R.string.importCancelButton, (dialog, id) -> dialog.cancel());
+        alert = builder.create();
+        alert.show();
+      }
+    }
+  );
 
   @SuppressLint("SdCardPath")
-  public void importDb()
-  {
-    // permission to read db
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
-    {
-      int hasReadStoragePermission = checkSelfPermission(Manifest.permission.READ_EXTERNAL_STORAGE);
-      if (hasReadStoragePermission != PackageManager.PERMISSION_GRANTED)
-      {
-        requestPermissions(new String[]{Manifest.permission.READ_EXTERNAL_STORAGE}, REQUEST_CODE_ASK_PERMISSIONS);
-      }
-    }
-    infile = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS) + "/beecount.db");
-    File outfile = getApplicationContext().getDatabasePath("beecount.db");
-    String extStorage = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS) + "/";
-    if(!(infile.exists()))
-    {
-      Toast.makeText(this,getString(R.string.noDb) + extStorage, Toast.LENGTH_LONG).show();
-      return;
-    }
-
-    // a confirm dialogue before anything else takes place
-    // http://developer.android.com/guide/topics/ui/dialogs.html#AlertDialog
-    // could make the dialog central in the popup - to do later
-    AlertDialog.Builder builder = new AlertDialog.Builder(this);
-    builder.setIcon(android.R.drawable.ic_dialog_alert);
-    builder.setMessage(R.string.confirmImport).setCancelable(false).setPositiveButton(R.string.importButton, new DialogInterface.OnClickListener()
-    {
-      public void onClick(DialogInterface dialog, int id)
-      {
-        // START
-        // replace this with another function rather than this lazy c&p
-        if (Environment.MEDIA_MOUNTED.equals(state))
-        {
-          // We can read and write the media
-          mExternalStorageAvailable = mExternalStorageWriteable = true;
-        } else if (Environment.MEDIA_MOUNTED_READ_ONLY.equals(state))
-        {
-          // We can only read the media
-          mExternalStorageAvailable = true;
-          mExternalStorageWriteable = false;
-        } else
-        {
-          // Something else is wrong. It may be one of many other states, but all we need
-          //  to know is we can neither read nor write
-          mExternalStorageAvailable = mExternalStorageWriteable = false;
-        }
-
-
-        if ((mExternalStorageAvailable == false) || (mExternalStorageWriteable == false))
-        {
-          Log.e(TAG, "No sdcard access");
-          Toast.makeText(getApplicationContext(), getString(R.string.noCard), Toast.LENGTH_SHORT).show();
-          return;
-        } else
-        {
-          try
-          {
-            copy(infile, outfile);
-            Toast.makeText(getApplicationContext(), getString(R.string.importWin), Toast.LENGTH_SHORT).show();
-          } catch (IOException e)
-          {
-            Log.e(TAG, "Failed to import database");
-            Toast.makeText(getApplicationContext(), getString(R.string.importFail), Toast.LENGTH_SHORT).show();
-            return;
-          }
-        }
-
-        // END
-      }
-    }).setNegativeButton(R.string.importCancelButton, new DialogInterface.OnClickListener()
-    {
-      public void onClick(DialogInterface dialog, int id)
-      {
-        dialog.cancel();
-      }
-    });
-    alert = builder.create();
-    alert.show();
+  public void importDb() {
+    Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+    intent.addCategory(Intent.CATEGORY_OPENABLE);
+    intent.setType("application/octet-stream");
+    importFileLauncher.launch(intent);
   }
-
-  // http://stackoverflow.com/questions/9292954/how-to-make-a-copy-of-a-file-in-android
-  public void copy(File src, File dst) throws IOException
-  {
-    FileInputStream in = new FileInputStream(src);
-    FileOutputStream out = new FileOutputStream(dst);
-
-    // Transfer bytes from in to out
-    byte[] buf = new byte[1024];
-    int len;
-    while ((len = in.read(buf)) > 0)
-    {
-      out.write(buf, 0, len);
-    }
-    in.close();
-    out.close();
-  }
-
-
-
 }

--- a/beecount/src/main/res/values-de/strings.xml
+++ b/beecount/src/main/res/values-de/strings.xml
@@ -37,11 +37,11 @@
     <!-- ListprojActivity -->
     <string name="noCard">Die SD-Karte kann nicht verwendet werden!</string>
     <string name="saveFail">Die Datenbank konnte nicht exportiert werden!</string>
-    <string name="saveWin">Die Datenbank wurde auf die SD-Karte exportiert.</string>
+    <string name="saveWin">Die Datenbank wurde in das gewählte Verzeichnis gespeichert.</string>
     <string name="exportMenu">Export</string>
     <string name="importMenu">Import</string>
     <string name="importFail">Die Datenbank konnte nicht importiert werden!</string>
-    <string name="importWin">Die Datenbank wurde von der SD-Karte importiert.</string>
+    <string name="importWin">Die Datenbank wurde aus der gewählten Datei importiert.</string>
     <string name="noDb">Bitte lege die \"beecount.db\" hier: </string>
     <string name="importButton">Import</string>
     <string name="importCancelButton">Abbrechen</string>

--- a/beecount/src/main/res/values-fr/strings.xml
+++ b/beecount/src/main/res/values-fr/strings.xml
@@ -38,11 +38,11 @@
     <!-- ListprojActivity -->
     <string name="noCard">On n\'a pas pu accéder au dossier \'Téléchargements\'!</string>
     <string name="saveFail">On n\'a pas pu exporter votre base de données!</string>
-    <string name="saveWin">Votre base de données a été exporté au dossier \'Téléchargements\'.</string>
+    <string name="saveWin">Votre base de données a été exportée dans le dossier selectionné.</string>
     <string name="exportMenu">Exporter</string>
     <string name="importMenu">Importer</string>
     <string name="importFail">On n\'a pas pu importer votre base de données!</string>
-    <string name="importWin">Votre base de données a été importé du dossier \'Téléchargements\'.</string>
+    <string name="importWin">Votre base de données a été importé du dossier selectionné</string>
     <string name="noDb">Veuillez mettre \'beecount.db\' ici: </string>
     <string name="importButton">Importer</string>
     <string name="importCancelButton">Annuler</string>

--- a/beecount/src/main/res/values/strings.xml
+++ b/beecount/src/main/res/values/strings.xml
@@ -38,7 +38,7 @@
     <!-- ListprojActivity -->
     <string name="noCard">Your sdcard could not be accessed!</string>
     <string name="saveFail">Your database could not be exported! Have you created any projects?</string>
-    <string name="saveWin">Your database has been exported to the Downloads folder.</string>
+    <string name="saveWin">Your database has been exported to your selected folder.</string>
     <string name="exportMenu">Export</string>
     <string name="importMenu">Import</string>
     <string name="importFail">Your database could not be imported!</string>


### PR DESCRIPTION
Hi, I changed my phone and also had problems when importing my old database. I debugged and found out that the app didn't have permission to read the file. I tried some tweaks, but ultimately it seems that there's nothing we can do now, except adding the file picker.
I implemented that, also fixed the export. I tried it on my phone with Android (API 36) and also in some emulators with API-Level 33 and 29. Seems to work.

FYI: I'll be away for the next week, so if you have some comments, I'll answer them later.